### PR TITLE
Bugfix: Initial example fails to resize height

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -63,12 +63,16 @@
 			lazyload: true,
 			debounce: 50,
 			onAppend: function(iframe) {
-				$(iframe)
-					.attr('id', 'frame-' + Math.random().toString().substr(2))
-					.iFrameResize({
-						heightCalculationMethod: 'lowestElement',
-						warningTimeout: 10000,
-					});
+				// delay the iFrameResize call to allow the iframeResizer.contentWindow.min.js script
+				// to load in the iframe first
+				setTimeout(function() {
+					$(iframe)
+						.attr('id', 'frame-' + Math.random().toString().substr(2))
+						.iFrameResize({
+							heightCalculationMethod: 'lowestElement',
+							warningTimeout: 10000,
+						});
+				}, 100);
 			},
 		});
 


### PR DESCRIPTION
On the initial page load, I almost always see this warning from the iFrameSizer:
![image](https://user-images.githubusercontent.com/3260193/32301062-827edf12-bf19-11e7-80c5-239b7cd6c33e.png)
which is referencing the example's iframe that initially loaded in the viewport. This example's iframe also fails to resize properly to the content inside of the iframe. Scrolling down to other examples, this warning message does not appear, and these examples do resize properly.

After turning on the `log` flag in the iFrameResizer, I see that it sends its initial message to the contentWindow but receives no response, and doesn't attempt to send the message again, leading to this warning. I am assuming that this is a race condition between the iFrameResizer host and the contentWindow script, where the host is expecting that the contentWindow script has already loaded when it sends its initial connection message. I haven't looked into that library's code to attempt to resolve that race condition, and it probably is worth letting them know about this condition. But as a hotfix, I did find that wrapping the `.iFrameResize` call in a `setTimeout` gave enough time for this race condition to not occur (at least from my ad hoc testing).