### PR TITLE
Multiple sources of documentation for the same item

### DIFF
--- a/src/templates/index.handlebars
+++ b/src/templates/index.handlebars
@@ -57,6 +57,55 @@
 		<script src="_stylemark/js/vendor/lazyframe.min.js"></script>
 		<script src="_stylemark/js/vendor/highlight.min.js"></script>
 		<script src="_stylemark/js/vendor/clipboard.min.js"></script>
-		<script src="_stylemark/js/app.js"></script>
+		<script src="_stylemark/js/app.js"></script>	
+		<script>
+      		
+		      $(function() {
+
+			lastID = 0;
+
+			$('.i-library').each(function(){
+
+			  currentID = $(this).attr('id');
+			  console.log(currentID);
+			  if (lastID === currentID){
+
+			    $(this).addClass('repeated')
+
+			  }else{
+			    $(this).addClass('unic')
+			  }
+			  $('.repeated').css('margin-top','-10px');
+			  $('.repeated .display-4').hide();
+
+
+			  lastID = $(this).attr('id');
+
+			});
+
+			lastFilter = 0;
+
+			$('.i-sidebar-list-item').each(function(){
+
+			  currentFilter = $(this).attr('data-filter-value');
+			  console.log(currentFilter);
+			  if (lastFilter === currentFilter){
+
+			    $(this).addClass('repeated-item')
+
+			  }else{
+			    $(this).addClass('unic-item')
+			  }
+			  $('.repeated-item').hide();
+
+			  lastFilter = $(this).attr('data-filter-value');
+
+			});  
+
+		      });  		
+
+		</script>
+		
+		
 	</body>
 </html>


### PR DESCRIPTION
This change allows us to split the component's documentation in more than one file to keep things organized.

Example:

# 1st source of documentation ( CSS ):
## component.css -> Component Name + HTML example
```

---
name: Accordion
category: Components
---

Your description

```
# 2nd source of documentation ( JS ):
## component.js - > Component JS methods, API, etc.


```
---
name: Accordion // Same name as in the CSS file
category: Components // Same name as in the CSS file
---
#Methods
| Name  | Description   |
|---|---|
|  $('#id').collapse() |  It toogles beetwen hidden / visible |
|  $('#id').collapse('show') |  It shows the collapse |
|  $('#id').collapse('hide')   | It hides the collapse  |
```

This would create a double item both in the sidebar and in the content, this jQuery hides the duplicated item in the sidebar and changes the style of the duplicated items in the content so the documentation appears as is the same item.

This could be better done editing the node.js files and handlebars to add a "subcategory" option but this is a, albeit dirty,  faster way to implement it.