### PR TITLE
Fix external sources description replacement

### DIFF
--- a/test/external-sources-examples-expected-output.txt
+++ b/test/external-sources-examples-expected-output.txt
@@ -1,0 +1,60 @@
+
+Single Source
+-------------
+An example can reference a single external source with a relative path:
+
+<example name="single-source-relative"></example>
+```single-source-relative.html
+<div id="data">External Example Template</div>
+```
+
+Or with an absolute path (based on the runtime directory):
+
+<example name="single-source-absolute"></example>
+```single-source-absolute.html
+<div id="data">External Example Template</div>
+```
+
+Mixed with Inline Sources
+----------------------------
+An example can combine external sources with inline sources:
+
+<example name="mixed-sources"></example>
+```mixed-sources.html
+<div id="data">External Example Template</div>
+```
+```mixed-sources.js
+var data2 = {};
+```
+
+Multiple Sources
+----------------
+An example can reference multiple sources individually:
+
+<example name="multiple-sources"></example>
+```multiple-sources.html
+<div id="data">External Example Template</div>
+```
+```multiple-sources.js
+var data = {};
+```
+
+or with a wildcard:
+
+```multiple-sources-wildcard.js
+var data = {};
+```
+<example name="multiple-sources-wildcard"></example>
+```multiple-sources-wildcard.html
+<div id="data">External Example Template</div>
+```
+
+Hidden Sources
+--------------
+An external source can also be hidden:
+
+<example name="hidden-sources"></example>
+```hidden-sources.html
+<div id="data-2">Inline Source Template</div>
+```
+

--- a/test/test.js
+++ b/test/test.js
@@ -269,6 +269,8 @@ describe('A processed source code file', () => {
 });
 
 describe('A processed source code file with external source examples', () => {
+	var expectedOutputFilepath = 'test/external-sources-examples-expected-output.txt';
+	var expectedOutput = fs.readFileSync(expectedOutputFilepath, 'utf8');
 	var filepath = 'test/external-sources-examples.js';
 	var content = fs.readFileSync(filepath, 'utf8');
 	var language = path.extname(filepath).substr(1);
@@ -371,5 +373,8 @@ describe('A processed source code file with external source examples', () => {
 			options: {},
 		}));
 
+		it('should have replaced the external source references in the description', () => expect(components[0].getDescription()).to.equal(
+			expectedOutput
+		));
 	});
 });


### PR DESCRIPTION
Fixes the bug outlined in #15

I personally think this is a bit of a hack, but it was the most straightforward way to implement this without touching the generator (which I was hesitant to touch due to the lack of tests).

Unlike PR https://github.com/nextbigsoundinc/stylemark/pull/12, this time I actually did run the stylemark executable against the test directory, and visually verified that the index.html file is generated properly for the external sources