### PR TITLE
Prevent overwriting of HTML when combined with JSX and/or Handlebars

### DIFF
--- a/src/templates/example.handlebars
+++ b/src/templates/example.handlebars
@@ -61,6 +61,13 @@
 					return;
 				}
 
+				var application = getStylemarkBlock('angularjs');
+
+				// There is no application to evaluate
+				if (!application) {
+					return;
+				}
+
 				var moduleElem = document.querySelector('[ng-app]');
 				var module;
 
@@ -74,7 +81,7 @@
 				}
 
 				module.controller('stylemark-{{doc.slug}}-{{example.name}}', function($scope) {
-					$scope.$eval(getStylemarkBlock('angularjs'));
+					$scope.$eval(application);
 				});
 			})(window.angular);
 		</script>
@@ -86,6 +93,12 @@
 				}
 
 				var Component = eval(getStylemarkBlock('jsx'));
+
+				// There is no Component to render
+				if (!Component) {
+					return;
+				}
+
 				var rootNode = document.getElementById('stylemark-root');
 				ReactDOM.render(Component, rootNode);
 			})(window.ReactDOM);
@@ -97,11 +110,17 @@
 					return;
 				}
 
+				var hbs = getStylemarkBlock('handlebars') || getStylemarkBlock('hbs');
+
+				// There is no template to render
+				if (!hbs) {
+					return;
+				}
+
 				var render = function() {
 					var app = window.{{or options.emberAppName 'noop'}}
 					var container = app.__container__;
 					var renderer = container.lookup('renderer:-dom');
-					var hbs = getStylemarkBlock('handlebars') || getStylemarkBlock('hbs');
 					var template = Ember.HTMLBars.compile(hbs);
 
 					var context;

--- a/src/templates/example.handlebars
+++ b/src/templates/example.handlebars
@@ -30,20 +30,20 @@
 
 	{{{or options.bodyTag "<body>"}}}
 
-		<main
-			role="main"
-			id="stylemark-root"
-			ng-controller="stylemark-{{doc.slug}}-{{example.name}}"
-			style="
-				display: block;
-				padding: {{renderOptions.padding}};
-				width: {{renderOptions.width}};
-			"
-		>
-			{{~#each example.blocks}}
-				{{~#if (compare language "==" "html")}}{{{content}}}{{/if~}}
-			{{/each~}}
-		</main>
+		{{~#each example.blocks}}
+			{{~#if (compare language "==" "html")}}
+				{{{content}}}
+			{{/if~}}
+			{{~#if (compare language "==" "angularjs")}}
+				<main ng-controller="stylemark-{{doc.slug}}-{{example.name}}"></main>
+			{{/if~}}
+			{{~#if (compare language "==" "jsx")}}
+				<main id="stylemark-react-root"></main>
+			{{/if~}}
+			{{~#if (or (compare language "==" "handlebars") (compare language "==" "hbs"))}}
+				<main id="stylemark-ember-root"></main>
+			{{/if~}}
+		{{/each~}}
 
 		{{{options.bodyHtml}}}
 
@@ -57,14 +57,14 @@
 
 		<script>
 			(function(angular) {
+
 				if (!angular) {
 					return;
 				}
 
-				var application = getStylemarkBlock('angularjs');
+				var block = getStylemarkBlock('angularjs');
 
-				// There is no application to evaluate
-				if (!application) {
+				if (!block) {
 					return;
 				}
 
@@ -81,39 +81,40 @@
 				}
 
 				module.controller('stylemark-{{doc.slug}}-{{example.name}}', function($scope) {
-					$scope.$eval(application);
+					$scope.$eval(block);
 				});
 			})(window.angular);
 		</script>
 
 		<script>
 			(function(ReactDOM) {
+
 				if (!ReactDOM) {
 					return;
 				}
 
-				var Component = eval(getStylemarkBlock('jsx'));
+				var block = getStylemarkBlock('jsx');
 
-				// There is no Component to render
-				if (!Component) {
+				if (!block) {
 					return;
 				}
 
-				var rootNode = document.getElementById('stylemark-root');
+				var rootNode = document.getElementById('stylemark-react-root');
+				var Component = eval(block);
 				ReactDOM.render(Component, rootNode);
 			})(window.ReactDOM);
 		</script>
 
 		<script>
 			(function(Ember) {
+
 				if (!Ember) {
 					return;
 				}
 
-				var hbs = getStylemarkBlock('handlebars') || getStylemarkBlock('hbs');
+				var block = getStylemarkBlock('handlebars') || getStylemarkBlock('hbs');
 
-				// There is no template to render
-				if (!hbs) {
+				if (!block) {
 					return;
 				}
 
@@ -121,7 +122,7 @@
 					var app = window.{{or options.emberAppName 'noop'}}
 					var container = app.__container__;
 					var renderer = container.lookup('renderer:-dom');
-					var template = Ember.HTMLBars.compile(hbs);
+					var template = Ember.HTMLBars.compile(block);
 
 					var context;
 					eval('context = ' + getStylemarkBlock('js', '{}'));
@@ -154,7 +155,7 @@
 					};
 
 					compile(container, template, context).then(function(elem) {
-						jQuery('#stylemark-root').append(elem);
+						jQuery('#stylemark-ember-root').append(elem);
 					});
 				};
 


### PR DESCRIPTION
If an example contained an HTML as well as a JSX/Angular/Handlebars block, the HTML content was being inadvertently overwritten by the latter block.

For example, given:
~~~md
```example.html
<b>Hello, world!</b>
```
```example.jsx
<ButtonToolbar>
  <Button>Default</Button>
</ButtonToolbar>
```
~~~
The "Hello, world!" message would have been overwritten by the JSX example.

This PR fixes that behavior by using individual DOM elements to bind each JSX, Angular, and Handlebars block. h/t to @FlorianKoerner for identifying the issue and contributing to the fix with https://github.com/nextbigsoundinc/stylemark/pull/23