### PR TITLE
Performance: Debounce instead of throttle

### DIFF
--- a/bin/stylemark
+++ b/bin/stylemark
@@ -18,7 +18,7 @@ var delay = (watch === true) ? 2000 : watch;
 var browser = args.b;
 var port = _.isNumber(browser) ? browser : null;
 
-var generate = _.throttle(
+var generate = _.debounce(
 	function() {
 		console.log('Generating style guide...');
 		stylemark({
@@ -27,7 +27,8 @@ var generate = _.throttle(
 			configPath: configPath,
 		});
 	},
-	delay
+	delay,
+	{ leading: false, trailing: true }
 );
 
 generate();


### PR DESCRIPTION
I had some performance issues and tried to improve it a bit.
One of the improvements was to change from throttle to debounce.
* Explained: https://css-tricks.com/debouncing-throttling-explained-examples/



### Feature Sponsored by
If you like this change, feel free to review and accept this PR ;)
This feature/PR is sponsored by the company I work: [Garaio AG](https://www.garaio.com/)