### PR TITLE
Improved baseDir path

### DIFF
--- a/src/stylemark.js
+++ b/src/stylemark.js
@@ -33,7 +33,7 @@ function generate(params) {
 	options.output = output;
 	options.match = options.match || defaultMatchExtensions;
 	options.excludeDir = defaultExcludeDirectories.concat(options.excludeDir);
-	options.baseDir = options.baseDir ? findRoot(path.resolve(options.baseDir)) : findRoot(configPath);
+	options.baseDir = options.baseDir ? path.resolve(options.baseDir) : findRoot(configPath);
 
 	['match', 'excludeDir'].forEach(name => {
 		options[name] = _.isString(options[name]) ? new RegExp(options[name]) : options[name];


### PR DESCRIPTION
### Context
In our bigger project, the file structure doesn't allow us to put the stylemark folder next to the `node_modules`, which seems to be a problem when loading assets.

### Problem
Without this PR, the styleguide will copy the assets including the folder "SubProject1".
However, when you are within SASS/LESS/CSS etc. you don't mention the SubProject1 folder in filepaths, because its outside of the "Webroot". This makes it not really possible to load images, reference fonts etc.

### Solution
Improved **baseDir** handling within options, so it doesn't go out to the ` package.json` location.

I found out that I can solve the problem with removing the `findRoot` function call when the `options.baseDir` is set. (otherwise it will search the node_modules folder)

Assets can now be in any location, the baseDir option allows to improve the path of copied assets, especially if assets are not based on root path

### Example setup

- ProjectFolder/
  - package.json
  - node_modules/
  - SubProject1/
    - sass/
    - js/
    - images/
    - fonts/
    - StylemarkOutput/
      - images/
      - fonts/
  - SubProject2/
  - ...

This can now be solved with `stylemark.yml` settings and this PR:
Set the **baseDir**, and **don't** mention the **baseDir** within the assets:
```
baseDir: SubProject1

assets:
 - SubProject1/images
 - SubProject1/fonts
```

### Feature Sponsored by
If you like this change, feel free to review and accept this PR ;)
This feature/PR is sponsored by the company I work: [Garaio AG](https://www.garaio.com/)