### PR TITLE
Adding filename + path to identify location

### DIFF
--- a/src/templates/doc.handlebars
+++ b/src/templates/doc.handlebars
@@ -1,4 +1,5 @@
 <div id="{{doc.slug}}" class="i-library theme-content-element">
 	<h1 class="display-4 theme-content-element-title">{{doc.name}}</h1>
+	<span class="i-example__heading"><i class="fa fa-info-circle"></i> From file: {{doc.filepath}}</span>
 	<div class="theme-content-element-description">{{markdown doc.description}}</div>
 </div>


### PR DESCRIPTION
I simply wanted to see the source of a component output. This shows the full path of the file its generated from. Might help to identify in more complex scenarios.

![filepath](https://user-images.githubusercontent.com/840929/48124668-27b89e00-e27d-11e8-92cd-1a0408bf7cca.PNG)

### Feature Sponsored by
If you like this change, feel free to review and accept this PR ;)
This feature/PR is sponsored by the company I work: [Garaio AG](https://www.garaio.com/)