### PR TITLE
Fixing rfrModule loading issues

### DIFF
--- a/bin/stylemark
+++ b/bin/stylemark
@@ -8,6 +8,10 @@ var chokidar = require('chokidar');
 var bs = require('browser-sync').create();
 var _ = require('lodash');
 var path = require('path');
+
+// Fixing path issues when using this module as dependency (npm installs rfr module in my root node_modules)
+var stylemarkRootPath = path.resolve(__dirname, '..');
+rfr.setRoot(stylemarkRootPath);
 var stylemark = rfr('src/stylemark');
 
 var input = args.i;


### PR DESCRIPTION
### Issue

I forked your project and doing some changes.
I then use my package as dependency on an other client project.

The problem now is, that `npm install` somehow installs the rfr module in the client projects `node_modules` instead of within the stylemark package (`node_modules/stylemark/node_modules`) which would solve the problem.
I don't understand yet completely why this is happening, and why 
```
"bundleDependencies": [
    "rfr"
  ],
```
doesn't work as expected...

This is of course problematic, because you then use the RFR module to build up the file paths and this is in the wrong location.

### Solution
I could fix the path issues with setting the Root relative to its loaded file.

Within `bin/stylemark`:
```
var stylemarkRootPath = path.resolve(__dirname, '..');
rfr.setRoot(stylemarkRootPath);
```

### Feature Sponsored by
If you like this change, feel free to review and accept this PR ;)
This feature/PR is sponsored by the company I work: [Garaio AG](https://www.garaio.com/)