### PR TITLE
Make framework scripts conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Generating the HTML style guide
 stylemark({ input, output, configPath });
 ```
 
-Name | Type | Description
---- | --- | ---
-`input` | string | Directory where to read from
-`output` | string | Directory where to save the generated HTML
-`configPath` | string | (optional) Filepath of the stylemark YAML configuration file, defaults to `.stylemark.yml` within the input directory. See [Configuration](#configuration-file)
+| Name         | Type   | Description                                                                                                                                                     |
+|--------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `input`      | string | Directory where to read from                                                                                                                                    |
+| `output`     | string | Directory where to save the generated HTML                                                                                                                      |
+| `configPath` | string | (optional) Filepath of the stylemark YAML configuration file, defaults to `.stylemark.yml` within the input directory. See [Configuration](#configuration-file) |
 
 Example:
 ```js
@@ -110,13 +110,13 @@ stylemark({
 stylemark -i <input> -o <output> -c <configPath> -w [<delay>] -b [<port>]
 ```
 
-Name | Description
----  | ---
-`-i` | Directory where to read from
-`-o` | Directory where to save the generated HTML
-`-c` | (optional) Filepath of the stylemark YAML configuration file, defaults to `.stylemark.yml` within the input directory. See [Configuration](#configuration-file)
-`-w` | (optional) Will watch for file changes in `<input>` and rebuild the style guide, waiting at least `<delay>` milliseconds between successive changes (defaults to `2000`)
-`-b` | (optional) Will open the style guide in your default browser at `http://localhost:<port>` and will automatically reload it when the style guide is updated. The port will be chosen automatically if not provided.
+| Name | Description                                                                                                                                                                                                        |
+|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-i` | Directory where to read from                                                                                                                                                                                       |
+| `-o` | Directory where to save the generated HTML                                                                                                                                                                         |
+| `-c` | (optional) Filepath of the stylemark YAML configuration file, defaults to `.stylemark.yml` within the input directory. See [Configuration](#configuration-file)                                                    |
+| `-w` | (optional) Will watch for file changes in `<input>` and rebuild the style guide, waiting at least `<delay>` milliseconds between successive changes (defaults to `2000`)                                           |
+| `-b` | (optional) Will open the style guide in your default browser at `http://localhost:<port>` and will automatically reload it when the style guide is updated. The port will be chosen automatically if not provided. |
 
 **Example:** Build a style guide from `path/to/source/code` with a custom config file location, and save the generated HTML to `path/to/style/guide`
 ```sh
@@ -157,6 +157,10 @@ examples:
     bodyTag: (optional) <body> tag to use for each rendered example; defaults to "<body>"
     headHtml: (optional) HTML to insert before the closing </head> tag for each rendered example
     bodyHtml: (optional) HTML template of the example; the example's HTML content will be inserted in place of "{html}"
+
+angularjs: (optional) boolean. Support is added by default, if you do not use angular set to false to omit the script.
+react: (optional) boolean. Support is added by default, if you do not use react set to false to omit the script.
+ember: (optional) boolean. Support is added by default, if you do not use ember set to false to omit the script.
 
 webpackAppPath: For Webpack apps (esp. React, Angular, etc.), this is the `output.library` value in your webpack config
 emberAppName: For Ember apps, this is the name of the Ember app exported to the window object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,7 +1217,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1235,11 +1236,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1252,15 +1255,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1363,7 +1369,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1373,6 +1380,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1385,17 +1393,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -1412,6 +1423,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1484,7 +1496,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1494,6 +1507,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1569,7 +1583,8 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1599,6 +1614,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1616,6 +1632,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1654,11 +1671,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -3165,7 +3184,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3183,11 +3203,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3200,15 +3222,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3311,7 +3336,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3321,6 +3347,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3333,17 +3360,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3360,6 +3390,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3432,7 +3463,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3442,6 +3474,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3517,7 +3550,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3547,6 +3581,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3564,6 +3599,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3602,11 +3638,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/assets/js/stylemark/findAndHandleStylemarkBlocks/angularjs.js
+++ b/src/assets/js/stylemark/findAndHandleStylemarkBlocks/angularjs.js
@@ -1,0 +1,26 @@
+(function(angular) {
+    var docSlug = docSlug || '';
+    var exampleName = exampleName || '';
+    
+    if (!angular) {
+        return;
+    }
+
+    findAndHandleStylemarkBlocks('angularjs', function(block, index) {
+        var moduleElem = document.querySelector('[ng-app]');
+        var module;
+
+        if (moduleElem) {
+            // Uses an existing module
+            module = angular.module(moduleElem.getAttribute('ng-app'));
+        }
+        else {
+            // Creates a new module
+            module = angular.module('stylemark-' + docSlug + '-' + exampleName, []);
+        }
+
+        module.controller('stylemark-' + docSlug + '-' + exampleName + '-' + index, function($scope) {
+            $scope.$eval(block);
+        });
+    });
+})(window.angular);

--- a/src/assets/js/stylemark/findAndHandleStylemarkBlocks/ember.js
+++ b/src/assets/js/stylemark/findAndHandleStylemarkBlocks/ember.js
@@ -1,0 +1,70 @@
+(function(Ember) {
+    var stylemarkConf = stylemarkConf || {};
+    
+    if (!Ember) {
+        return;
+    }
+
+    findAndHandleStylemarkBlocks(['handlebars', 'hbs'], function(block, index) {
+        var render = function() {
+            var app = window[stylemarkConf.emberAppName] ||  window.noop
+            var container = app.__container__;
+            var renderer = container.lookup('renderer:-dom');
+            var template = Ember.HTMLBars.compile(block);
+
+            var jsBlocks = getStylemarkBlocks('js');
+            var jsBlock = jsBlocks && jsBlocks[0] ? jsBlocks[0] : '{}';
+            var context;
+            eval('context = ' + jsBlock);
+
+            // Credit:
+            // http://stackoverflow.com/questions/27950413/render-ember-js-hbs-template-to-a-string#answer-35625858
+            var compile = function(container, template, context) {
+                return new Ember.RSVP.Promise(function(resolve) {
+                    Ember.Component.extend(Ember.merge({
+                        style: 'display:none;',
+                        layout: template,
+                        container: container,
+                        renderer: renderer,
+
+                        init: function() {
+                            this._super.apply(this, arguments);
+                            Ember.setOwner(this, container);
+                        },
+
+                        didRender: function() {
+                            var elem = this.$();
+                            resolve(elem);
+                            this.destroy();
+                        }
+                    }, context))
+                        .create()
+                        .append();
+
+                });
+            };
+
+            compile(container, template, context).then(function(elem) {
+                var node = document.querySelectorAll('.stylemark-ember-root')[index];
+                jQuery(node).append(elem);
+            });
+        };
+
+        var isReady = function() {
+            var app = window[stylemarkConf.emberAppName] ||  window.noop;
+            return app && app.__container__;
+        };
+
+        var checkReady = function() {
+            if (isReady()) {
+                render();
+            }
+            else {
+                setTimeout(checkReady, 20);
+            }
+        };
+
+        checkReady();
+    });
+
+})(window.Ember);

--- a/src/assets/js/stylemark/findAndHandleStylemarkBlocks/findAndHandleStylemarkBlocks.js
+++ b/src/assets/js/stylemark/findAndHandleStylemarkBlocks/findAndHandleStylemarkBlocks.js
@@ -1,0 +1,32 @@
+function findAndHandleStylemarkBlocks(languages, handler) {
+    var blocks = getStylemarkBlocks(languages);
+    handleStylemarkBlocks(blocks, handler);
+}
+
+function getStylemarkBlocks(languages) {
+    languages = typeof languages === 'string' ? [languages] : languages;
+
+    var selectors = [];
+
+    for (var i = 0; i < languages.length; i++) {
+        selectors.push('script[data-language="' + languages[i] + '"]');
+    }
+
+    var selector = selectors.join(',');
+    var scripts = document.querySelectorAll(selector);
+    var blocks = [];
+
+    for (var i = 0, length = scripts.length; i < length; i++) {
+        if (scripts[i].innerText) {
+            blocks.push(scripts[i].innerText);
+        }
+    }
+
+    return blocks;
+}
+
+function handleStylemarkBlocks(blocks, handler) {
+    for (var i = 0, length = blocks.length; i < length; i++) {
+        handler(blocks[i], i);
+    }
+}

--- a/src/assets/js/stylemark/findAndHandleStylemarkBlocks/react.js
+++ b/src/assets/js/stylemark/findAndHandleStylemarkBlocks/react.js
@@ -1,0 +1,12 @@
+(function(ReactDOM) {
+
+    if (!ReactDOM) {
+        return;
+    }
+
+    findAndHandleStylemarkBlocks('jsx', function(block, index) {
+        var rootNode = document.querySelectorAll('.stylemark-react-root')[index];
+        var Component = eval(block);
+        ReactDOM.render(Component, rootNode);
+    });
+})(window.ReactDOM);

--- a/src/assets/js/stylemark/findAndHandleStylemarkBlocks/vanillajs.js
+++ b/src/assets/js/stylemark/findAndHandleStylemarkBlocks/vanillajs.js
@@ -1,0 +1,3 @@
+findAndHandleStylemarkBlocks('js', function(block) {
+    eval(block);
+});

--- a/src/handlebars.js
+++ b/src/handlebars.js
@@ -88,7 +88,10 @@ var helpers = {
 	replace: function(string, find, replace) {
 		string = string || '';
 		return string.replace(find, replace);
-	},
+    },
+    json: function(context) {
+        return JSON.stringify(context);
+    }
 };
 
 var partials = {

--- a/src/templates/example.handlebars
+++ b/src/templates/example.handlebars
@@ -2,6 +2,11 @@
 {{{or options.examples.htmlTag "<html>"}}}
 
 	<head>
+        <script>
+            var stylemarkConf = {{{json options}}};
+            var exampleName = "{{ example.name }}";
+            var docSlug = "{{doc.slug}}";
+        </script>
 		<style>
 			{{#each example.blocks}}
 				{{#if (compare language "==" "css")}}
@@ -16,41 +21,7 @@
 				height: auto !important;
 			}
 		</style>
-
-		<script>
-			function findAndHandleStylemarkBlocks(languages, handler) {
-				var blocks = getStylemarkBlocks(languages);
-				handleStylemarkBlocks(blocks, handler);
-			}
-
-			function getStylemarkBlocks(languages) {
-				languages = typeof languages === 'string' ? [languages] : languages;
-
-				var selectors = [];
-
-				for (var i = 0; i < languages.length; i++) {
-					selectors.push('script[data-language="' + languages[i] + '"]');
-				}
-
-				var selector = selectors.join(',');
-				var scripts = document.querySelectorAll(selector);
-				var blocks = [];
-
-				for (var i = 0, length = scripts.length; i < length; i++) {
-					if (scripts[i].innerText) {
-						blocks.push(scripts[i].innerText);
-					}
-				}
-
-				return blocks;
-			}
-
-			function handleStylemarkBlocks(blocks, handler) {
-				for (var i = 0, length = blocks.length; i < length; i++) {
-					handler(blocks[i], i);
-				}
-			}
-		</script>
+        <script src="_stylemark/js/stylemark/findAndHandleStylemarkBlocks/findAndHandleStylemarkBlocks.js"></script>
 
 		{{#each options.examples.css}}
 			<link rel="stylesheet" href="{{this}}">
@@ -87,142 +58,19 @@
 			<script type="text/x-stylemark" data-language="{{language}}">{{{content}}}</script>
 		{{/each}}
 
-		<!--
-			Vanilla JS
-		-->
-
-		<script>
-			findAndHandleStylemarkBlocks('js', function(block) {
-				eval(block);
-			});
-		</script>
-
-		<!--
-			AngularJS
-		-->
-
-		<script>
-			(function(angular) {
-
-				if (!angular) {
-					return;
-				}
-
-				findAndHandleStylemarkBlocks('angularjs', function(block, index) {
-					var moduleElem = document.querySelector('[ng-app]');
-					var module;
-
-					if (moduleElem) {
-						// Uses an existing module
-						module = angular.module(moduleElem.getAttribute('ng-app'));
-					}
-					else {
-						// Creates a new module
-						module = angular.module('stylemark-{{doc.slug}}-{{example.name}}', []);
-					}
-
-					module.controller('stylemark-{{doc.slug}}-{{example.name}}-' + index, function($scope) {
-						$scope.$eval(block);
-					});
-				});
-			})(window.angular);
-		</script>
-
-		<!--
-			React / JSX
-		-->
-
-		<script>
-			(function(ReactDOM) {
-
-				if (!ReactDOM) {
-					return;
-				}
-
-				findAndHandleStylemarkBlocks('jsx', function(block, index) {
-					var rootNode = document.querySelectorAll('.stylemark-react-root')[index];
-					var Component = eval(block);
-					ReactDOM.render(Component, rootNode);
-				});
-			})(window.ReactDOM);
-		</script>
-
-		<!--
-			Ember
-		-->
-
-		<script>
-			(function(Ember) {
-
-				if (!Ember) {
-					return;
-				}
-
-				findAndHandleStylemarkBlocks(['handlebars', 'hbs'], function(block, index) {
-					var render = function() {
-						var app = window.{{or options.emberAppName 'noop'}}
-						var container = app.__container__;
-						var renderer = container.lookup('renderer:-dom');
-						var template = Ember.HTMLBars.compile(block);
-
-						var jsBlocks = getStylemarkBlocks('js');
-						var jsBlock = jsBlocks && jsBlocks[0] ? jsBlocks[0] : '{}';
-						var context;
-						eval('context = ' + jsBlock);
-
-						// Credit:
-						// http://stackoverflow.com/questions/27950413/render-ember-js-hbs-template-to-a-string#answer-35625858
-						var compile = function(container, template, context) {
-							return new Ember.RSVP.Promise(function(resolve) {
-								Ember.Component.extend(Ember.merge({
-									style: 'display:none;',
-									layout: template,
-									container: container,
-									renderer: renderer,
-
-									init: function() {
-										this._super.apply(this, arguments);
-										Ember.setOwner(this, container);
-									},
-
-									didRender: function() {
-										var elem = this.$();
-										resolve(elem);
-										this.destroy();
-									}
-								}, context))
-									.create()
-									.append();
-
-							});
-						};
-
-						compile(container, template, context).then(function(elem) {
-							var node = document.querySelectorAll('.stylemark-ember-root')[index];
-							jQuery(node).append(elem);
-						});
-					};
-
-					var isReady = function() {
-						return window.{{or options.emberAppName 'noop'}}
-							&& window.{{or options.emberAppName 'noop'}}.__container__;
-					};
-
-					var checkReady = function() {
-						if (isReady()) {
-							render();
-						}
-						else {
-							setTimeout(checkReady, 20);
-						}
-					};
-
-					checkReady();
-				});
-
-			})(window.Ember);
-		</script>
-
+        <script src="_stylemark/js/stylemark/findAndHandleStylemarkBlocks/vanillajs.js"></script>
+        
+        {{#if (or (compare options.angularjs "===" undefined) (compare options.angularjs "===" true)) }}
+		<script src="_stylemark/js/stylemark/findAndHandleStylemarkBlocks/angularjs.js"></script>
+        {{/if~}}
+        
+        {{#if (or (compare options.react "===" undefined) (compare options.react "===" true)) }}
+		<script src="_stylemark/js/stylemark/findAndHandleStylemarkBlocks/react.js"></script>
+        {{/if~}}
+        
+        {{#if (or (compare options.ember "===" undefined) (compare options.ember "===" true)) }}
+		<script src="_stylemark/js/stylemark/findAndHandleStylemarkBlocks/ember.js"></script>
+        {{/if~}}
 		<script src="_stylemark/js/vendor/iframeResizer.contentWindow.min.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Moved angularjs, react and ember scripts out of the handlebars example into separate files and added conditional checks to add the scripts. Setup is done in a non breaking way, by default all scripts will be added.

Motivation for change:
- Improve performance by centralizing the scripts preventing having to load the same code multiple times.
- Add ability to omit all scripts when using a different setup/framework (in my case Aurelia)
- Make it easy to overwrite the scripts if needed